### PR TITLE
Omniauth paired - User Story 13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'figaro'
 gem 'google-api-client'
 gem 'jquery'
 gem 'active_designer'
+gem 'omniauth-github'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
 gem 'omniauth-google-oauth2'
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-github (1.3.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-google-oauth2 (0.8.0)
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
@@ -354,6 +357,7 @@ DEPENDENCIES
   launchy
   listen
   omniauth-census!
+  omniauth-github
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/users/github_info_controller.rb
+++ b/app/controllers/users/github_info_controller.rb
@@ -1,0 +1,10 @@
+class Users::GithubInfoController < ApplicationController
+  def show
+    info = request.env['omniauth.auth']
+    current_user.update_attribute(:token, info[:credentials][:token])
+    current_user.update_attribute(:username, info[:info][:nickname])
+    current_user.update_attribute(:github_id, info[:uid])
+
+    redirect_to '/dashboard'
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
+    @user_facade = UserFacade.new(current_user)
   end
 
   def new

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,0 +1,6 @@
+class UserFacade < SimpleDelegator
+  def initialize(user)
+    super(user)
+  end
+  
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,19 @@
 <section class="dashboard-main">
-  <h1> <%= current_user.first_name %>'s Dashboard </h1>
-
+  <h1> <%= @user_facade.first_name %>'s Dashboard </h1>
+  <%= button_to 'Connect to GitHub', github_login_path %>
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
-    <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
-    <li> <%= current_user.email%> </li>
+    <li> <%= @user_facade.first_name  %> <%= @user_facade.last_name %> </li>
+    <li> <%= @user_facade.email%> </li>
   </ul>
   <section>
     <h1>Bookmarked Segments</h1>
   </section>
+  <% unless @user_facade.token.nil? %>
+    <section class="github_info">
+      <h3>GitHub Info</h3>
+      <p>GitHub Username: <%= @user_facade.username %> </p>
+    </section>
+  <% end %>
 </section>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,3 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  provider :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'read,user,repo'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'auth/github', as: 'github_login'
+  get '/auth/github/callback', to: 'users/github_info#show'
+
   get '/login', to: "sessions#new"
   post '/login', to: "sessions#create"
   delete '/logout', to: "sessions#destroy"

--- a/db/migrate/20191206185442_add_details_to_users.rb
+++ b/db/migrate/20191206185442_add_details_to_users.rb
@@ -1,0 +1,7 @@
+class AddDetailsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :token, :string
+    add_column :users, :username, :string
+    add_column :users, :github_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_230036) do
+ActiveRecord::Schema.define(version: 2019_12_06_185442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,9 @@ ActiveRecord::Schema.define(version: 2018_07_31_230036) do
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token"
+    t.string "username"
+    t.string "github_id"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/user/connect_to_github_spec.rb
+++ b/spec/features/user/connect_to_github_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'user can be authenticated and grant acces via github' do
+  it 'authenticates user and fetches user info from github' do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    stub_omniauth
+    visit '/dashboard'
+    expect(page).to_not have_css('.github_info')
+    click_button 'Connect to GitHub'
+
+    expect(current_path).to eq('/dashboard')
+    expect(page).to have_content(user.email)
+    expect(page).to have_content(user.first_name)
+    expect(page).to have_content(user.last_name)
+    expect(page).to have_css('.github_info')
+
+    within('.github_info') do
+      expect(page).to have_content(user.username)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,3 +49,8 @@ RSpec.configure do |config|
 
   config.filter_rails_from_backtrace!
 end
+
+def stub_omniauth
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.add_mock(:github, {:uid => '12345', :credentials => {token: "importanttoken"}, :info => {nickname: 'github_name'}})
+end


### PR DESCRIPTION
User Story 13 of Connecting GitHub info to a signed-in user is functional and tested using omni_auth stub.

current_user resource gets updated with a token, github_id, and username

'/dashboard' users#show fetches a user_facade that decorates a user and will allow us to extend methods of .repos, .followers, .following for future user stories.

Rspec passing with 77% coverage